### PR TITLE
add-env-option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `--env` option for declaring env variables in command line. [#8]
+
 ## [0.1.0] - 2021-06-25
 
 ### First Release :tada:
 
 [unreleased]: https://github.com/supertone-inc/envjs/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/supertone-inc/envjs/releases/tag/v0.1.0
+[#8]: https://github.com/supertone-inc/envjs/pull/8

--- a/src/main.js
+++ b/src/main.js
@@ -15,8 +15,9 @@ function main() {
 
   const program = argParser.parse();
 
-  const envFilePath = resolve(program.opts().file);
-  const env = { ...process.env, ...parseEnvFile(envFilePath) };
+  const options = program.opts();
+  const envFilePath = resolve(options.file);
+  const env = { ...process.env, ...parseEnvFile(envFilePath), ...options.env };
   const command = replaceEnvVars(program.args.join(" "), env);
 
   execSync(command, { env, stdio: "inherit" });

--- a/src/parseArgs.js
+++ b/src/parseArgs.js
@@ -3,12 +3,25 @@ const pkg = require("../package.json");
 
 const name = pkg.name.split("/")[1];
 
+function convertEnvOption(value, previous) {
+  const [envKey, envValue] = value.split("=").map((string) => string.trim());
+
+  return {
+    ...previous,
+    [envKey]: envValue,
+  };
+}
+
 function createArgParser() {
   return new Command()
     .name(name)
     .argument("<command>", "command to run with env variables")
     .option("-f, --file <path>", "env file path", ".env.js")
-    .option("-e, --env <key=value...>", "additional env key-value pairs")
+    .option(
+      "-e, --env <key=value...>",
+      "additional env key-value pairs",
+      convertEnvOption
+    )
     .helpOption("-h, --help", "display help")
     .addHelpText(
       "after",

--- a/src/parseArgs.js
+++ b/src/parseArgs.js
@@ -8,9 +8,10 @@ module.exports = function parseArgs(argv, options) {
     .name(name)
     .arguments("<command>")
     .description("", {
-      command: "a command to run with env variables",
+      command: "command to run with env variables",
     })
     .option("-f, --file <path>", "env file path", ".env.js")
+    .option("-e, --env <key=value...>", "additional env key pairs")
     .helpOption("-h, --help", "display help")
     .addHelpText(
       "after",

--- a/src/parseArgs.test.js
+++ b/src/parseArgs.test.js
@@ -28,6 +28,66 @@ it("parses --file option correctly", () => {
   });
 });
 
+it("parses --env option correctly", () => {
+  function parseOptions(command) {
+    return parseArgs(command.split(" ")).opts();
+  }
+
+  const defaultOptions = { file: ".env.js" };
+
+  expect(parseOptions(`${script} -e ENV_VAR0=env-var0`)).toEqual({
+    ...defaultOptions,
+    env: ["ENV_VAR0=env-var0"],
+  });
+
+  expect(
+    parseOptions(`${script} -e ENV_VAR0=env-var0 ENV_VAR1=env-var1`)
+  ).toEqual({
+    ...defaultOptions,
+    env: ["ENV_VAR0=env-var0", "ENV_VAR1=env-var1"],
+  });
+
+  expect(
+    parseOptions(`${script} -e ENV_VAR0=env-var0 -e ENV_VAR1=env-var1`)
+  ).toEqual({
+    ...defaultOptions,
+    env: ["ENV_VAR0=env-var0", "ENV_VAR1=env-var1"],
+  });
+
+  expect(
+    parseOptions(`${script} -e ENV_VAR0=env-var0 -e ENV_VAR0=env-var1`)
+  ).toEqual({
+    ...defaultOptions,
+    env: ["ENV_VAR0=env-var0", "ENV_VAR0=env-var1"],
+  });
+
+  expect(parseOptions(`${script} --env ENV_VAR0=env-var0`)).toEqual({
+    ...defaultOptions,
+    env: ["ENV_VAR0=env-var0"],
+  });
+
+  expect(
+    parseOptions(`${script} --env ENV_VAR0=env-var0 ENV_VAR1=env-var1`)
+  ).toEqual({
+    ...defaultOptions,
+    env: ["ENV_VAR0=env-var0", "ENV_VAR1=env-var1"],
+  });
+
+  expect(
+    parseOptions(`${script} --env ENV_VAR0=env-var0 --env ENV_VAR1=env-var1`)
+  ).toEqual({
+    ...defaultOptions,
+    env: ["ENV_VAR0=env-var0", "ENV_VAR1=env-var1"],
+  });
+
+  expect(
+    parseOptions(`${script} --env ENV_VAR0=env-var0 --env ENV_VAR0=env-var1`)
+  ).toEqual({
+    ...defaultOptions,
+    env: ["ENV_VAR0=env-var0", "ENV_VAR0=env-var1"],
+  });
+});
+
 it("parses arguments correctly", () => {
   function parseArguments(command) {
     return parseArgs(command.split(" ")).args;

--- a/src/parseArgs.test.js
+++ b/src/parseArgs.test.js
@@ -33,40 +33,43 @@ it("parses --env option correctly", () => {
     return parseArgs(createArgv(command)).opts();
   }
 
-  const defaultOptions = { file: ".env.js" };
-
-  expect(parseOptions(`envjs -e ENV_VAR0=env-var0 -- <command>`)).toEqual({
-    ...defaultOptions,
-    env: ["ENV_VAR0=env-var0"],
-  });
+  expect(parseOptions(`envjs -e ENV_VAR0=env-var0 -- <command>`)).toEqual(
+    expect.objectContaining({
+      env: ["ENV_VAR0=env-var0"],
+    })
+  );
 
   expect(
     parseOptions(`envjs -e ENV_VAR0=env-var0 ENV_VAR1=env-var1 -- <command>`)
-  ).toEqual({
-    ...defaultOptions,
-    env: ["ENV_VAR0=env-var0", "ENV_VAR1=env-var1"],
-  });
+  ).toEqual(
+    expect.objectContaining({
+      env: ["ENV_VAR0=env-var0", "ENV_VAR1=env-var1"],
+    })
+  );
 
   expect(
     parseOptions(`envjs -e ENV_VAR0=env-var0 ENV_VAR0=env-var1 -- <command>`)
-  ).toEqual({
-    ...defaultOptions,
-    env: ["ENV_VAR0=env-var0", "ENV_VAR0=env-var1"],
-  });
+  ).toEqual(
+    expect.objectContaining({
+      env: ["ENV_VAR0=env-var0", "ENV_VAR0=env-var1"],
+    })
+  );
 
   expect(
     parseOptions(`envjs -e ENV_VAR0=env-var0 -e ENV_VAR1=env-var1 -- <command>`)
-  ).toEqual({
-    ...defaultOptions,
-    env: ["ENV_VAR0=env-var0", "ENV_VAR1=env-var1"],
-  });
+  ).toEqual(
+    expect.objectContaining({
+      env: ["ENV_VAR0=env-var0", "ENV_VAR1=env-var1"],
+    })
+  );
 
   expect(
     parseOptions(`envjs -e ENV_VAR0=env-var0 -e ENV_VAR0=env-var1 -- <command>`)
-  ).toEqual({
-    ...defaultOptions,
-    env: ["ENV_VAR0=env-var0", "ENV_VAR0=env-var1"],
-  });
+  ).toEqual(
+    expect.objectContaining({
+      env: ["ENV_VAR0=env-var0", "ENV_VAR0=env-var1"],
+    })
+  );
 });
 
 it("parses arguments correctly", () => {

--- a/src/parseArgs.test.js
+++ b/src/parseArgs.test.js
@@ -35,7 +35,7 @@ it("parses --env option correctly", () => {
 
   expect(parseOptions(`envjs -e ENV_VAR0=env-var0 -- <command>`)).toEqual(
     expect.objectContaining({
-      env: ["ENV_VAR0=env-var0"],
+      env: { ENV_VAR0: "env-var0" },
     })
   );
 
@@ -43,7 +43,7 @@ it("parses --env option correctly", () => {
     parseOptions(`envjs -e ENV_VAR0=env-var0 ENV_VAR1=env-var1 -- <command>`)
   ).toEqual(
     expect.objectContaining({
-      env: ["ENV_VAR0=env-var0", "ENV_VAR1=env-var1"],
+      env: { ENV_VAR0: "env-var0", ENV_VAR1: "env-var1" },
     })
   );
 
@@ -51,7 +51,7 @@ it("parses --env option correctly", () => {
     parseOptions(`envjs -e ENV_VAR0=env-var0 ENV_VAR0=env-var1 -- <command>`)
   ).toEqual(
     expect.objectContaining({
-      env: ["ENV_VAR0=env-var0", "ENV_VAR0=env-var1"],
+      env: { ENV_VAR0: "env-var0", ENV_VAR0: "env-var1" },
     })
   );
 
@@ -59,7 +59,7 @@ it("parses --env option correctly", () => {
     parseOptions(`envjs -e ENV_VAR0=env-var0 -e ENV_VAR1=env-var1 -- <command>`)
   ).toEqual(
     expect.objectContaining({
-      env: ["ENV_VAR0=env-var0", "ENV_VAR1=env-var1"],
+      env: { ENV_VAR0: "env-var0", ENV_VAR1: "env-var1" },
     })
   );
 
@@ -67,7 +67,7 @@ it("parses --env option correctly", () => {
     parseOptions(`envjs -e ENV_VAR0=env-var0 -e ENV_VAR0=env-var1 -- <command>`)
   ).toEqual(
     expect.objectContaining({
-      env: ["ENV_VAR0=env-var0", "ENV_VAR0=env-var1"],
+      env: { ENV_VAR0: "env-var0", ENV_VAR0: "env-var1" },
     })
   );
 });


### PR DESCRIPTION
## Summary
- Add `-e, --env` option.
- Parse "key=value" strings to an object.